### PR TITLE
Handle session where no groups exist

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -60,8 +60,10 @@ export const en = {
     createGroupButton: "Create a new group",
     switchGroupButton: "Switch to this group",
     alreadyCurrentGroup: "Already current group",
-    notInGroup: "You are not part of any group",
+    notInGroup: "No group found",
     noMembers: "No members added",
+    infoMustCreateGroup:
+      "Please create a new group, or get invited in an existing group",
     successGroupCreated: "Group created",
     successAddMember: "Member added",
     successGroupSwitch: "Group switched to",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ const HomePage: NextPage = () => {
 
   return (
     <LayoutDefault>
-      <section className={styles.signinContainer}>
+      <section className={styles.genericContainer}>
         <h2>{t.common.choaresTitle}</h2>
         <p>{t.common.choaresSubtitle}</p>
         {status === "loading" ? (

--- a/styles/Groups.module.scss
+++ b/styles/Groups.module.scss
@@ -28,11 +28,6 @@
 .groupDetails {
   margin-bottom: 2rem;
 
-  h2 {
-    margin-bottom: 0.5rem;
-    font-size: fonts.$bigger;
-  }
-
   p {
     margin-bottom: 0.5rem;
   }

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -75,15 +75,11 @@
   }
 }
 
-.signinContainer {
+.genericContainer {
+  width: 100%;
   margin: auto 0;
   align-self: center;
   text-align: center;
-
-  h2 {
-    font-size: fonts.$bigger;
-    margin-bottom: 0.5rem;
-  }
 
   p {
     margin-bottom: 1rem;

--- a/styles/Settings.module.scss
+++ b/styles/Settings.module.scss
@@ -1,11 +1,6 @@
 @use "fonts";
 
 .settingsContainer {
-  h2 {
-    font-size: fonts.$bigger;
-    margin-bottom: 1rem;
-  }
-
   button {
     margin-bottom: 1rem;
   }

--- a/styles/Tasks.module.scss
+++ b/styles/Tasks.module.scss
@@ -48,11 +48,6 @@
 .taskDetails {
   margin-bottom: 2rem;
 
-  h2 {
-    margin-bottom: 0.5rem;
-    font-size: fonts.$bigger;
-  }
-
   p {
     margin-bottom: 0.5rem;
   }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,11 +1,13 @@
 @use "colors";
+@use "fonts";
 
 html,
 body {
   padding: 0;
   margin: 0;
   color: colors.$secondary;
-  font-family: Helvetica Neue, Helvetica, sans-serif;
+  font-size: 16px;
+  font-family: "Helvetica Neue", Helvetica, sans-serif;
 }
 
 h1,
@@ -18,12 +20,18 @@ p {
   margin: 0;
 }
 
+h2 {
+  font-size: fonts.$bigger;
+  margin-bottom: 0.5rem;
+}
+
 a {
   color: inherit;
   text-decoration: underline;
   color: colors.$secondary;
 }
 
+ol,
 ul {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
This PR fixes the issue where if no group exists for a user, nothing would work.

When a user is logged in and has no group to be set as current group:
* We display a page overlay to inform the user, and invite them to create a group
* Only the group creation form can be accessed; on every other routes, the overlay is displayed

We have also updated the layout auth logic, so that it better handles loadings state (should limit blinking UI)
